### PR TITLE
Support array result include sequence action

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ export default (args: any) => {
   }
 }
 ```
+For the return result, not only support `dictionary` but also support `array`
+
+So a very simple `hello array` function would be:
+
+```ts
+export default (args: any) => {
+   return ["a", "b"]
+}
+```
+
+And support array result for sequence action as well, the first action's array result can be used as next action's input parameter.
+
+So the function can be:
+
+```ts
+func main(args: Any) -> Any {
+    return args
+}
+```
+When invokes above action, we can pass an array object as the input parameter.
 
 ## Development
 

--- a/deno1.3.0/Dockerfile
+++ b/deno1.3.0/Dockerfile
@@ -17,8 +17,8 @@
 
 # build go proxy from source
 FROM golang:1.18 AS builder_source
-ARG GO_PROXY_GITHUB_USER=ningyougang
-ARG GO_PROXY_GITHUB_BRANCH=support-array-result-include-sequence-action
+ARG GO_PROXY_GITHUB_USER=apache
+ARG GO_PROXY_GITHUB_BRANCH=master
 RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
    https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src ;\
    cd /src ; env GO111MODULE=on CGO_ENABLED=0 go build main/proxy.go && \

--- a/deno1.3.0/Dockerfile
+++ b/deno1.3.0/Dockerfile
@@ -25,8 +25,8 @@ RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
    mv proxy /bin/proxy
 
 # or build it from a release
-FROM golang:1.15 AS builder_release
-ARG GO_PROXY_RELEASE_VERSION=1.15@1.17.0
+FROM golang:1.18 AS builder_release
+ARG GO_PROXY_RELEASE_VERSION=1.18@1.20.0
 RUN curl -sL \
   https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\
   | tar xzf -\
@@ -36,7 +36,7 @@ RUN curl -sL \
 FROM hayd/alpine-deno:1.3.0
 
 # select the builder to use
-ARG GO_PROXY_BUILD_FROM=source
+ARG GO_PROXY_BUILD_FROM=release
 
 COPY --from=builder_source /bin/proxy /bin/proxy_source
 COPY --from=builder_release /bin/proxy /bin/proxy_release

--- a/deno1.3.0/Dockerfile
+++ b/deno1.3.0/Dockerfile
@@ -16,9 +16,9 @@
 #
 
 # build go proxy from source
-FROM golang:1.15 AS builder_source
-ARG GO_PROXY_GITHUB_USER=apache
-ARG GO_PROXY_GITHUB_BRANCH=master
+FROM golang:1.18 AS builder_source
+ARG GO_PROXY_GITHUB_USER=ningyougang
+ARG GO_PROXY_GITHUB_BRANCH=support-array-result-include-sequence-action
 RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
    https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src ;\
    cd /src ; env GO111MODULE=on CGO_ENABLED=0 go build main/proxy.go && \
@@ -31,12 +31,12 @@ RUN curl -sL \
   https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\
   | tar xzf -\
   && cd openwhisk-runtime-go-*/main\
-  && GO111MODULE=on go build -o /bin/proxy
+  && GO111MODULE=on CGO_ENABLED=0 go build -o /bin/proxy
 
 FROM hayd/alpine-deno:1.3.0
 
 # select the builder to use
-ARG GO_PROXY_BUILD_FROM=release
+ARG GO_PROXY_BUILD_FROM=source
 
 COPY --from=builder_source /bin/proxy /bin/proxy_source
 COPY --from=builder_release /bin/proxy /bin/proxy_release

--- a/deno1.3.0/lib/launcher.js
+++ b/deno1.3.0/lib/launcher.js
@@ -38,7 +38,7 @@ for await (const line of readLines(Deno.stdin)) {
     if (await exists(sourceCode)) {
       const {default: main} = await import(sourceCode);
       response = await main(payload);
-      if (Object.prototype.toString.call(response) !== '[object Object]') {
+      if (Object.prototype.toString.call(response) !== '[object Object]' && Object.prototype.toString.call(response) !== '[object Array]') {
         response = {
           error: 'response returned by the function is not an object'
         };

--- a/tests/src/test/scala/runtime/actionContainers/SingleTest.scala
+++ b/tests/src/test/scala/runtime/actionContainers/SingleTest.scala
@@ -21,7 +21,7 @@ import actionContainers.{ActionContainer, ActionProxyContainerTestUtils}
 import common.WskActorSystem
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import spray.json.{JsonParser}
+import spray.json.{JsArray, JsObject, JsString, JsonParser}
 
 @RunWith(classOf[JUnitRunner])
 class SingleTest extends ActionProxyContainerTestUtils with WskActorSystem {
@@ -49,6 +49,21 @@ class SingleTest extends ActionProxyContainerTestUtils with WskActorSystem {
       initCode should be(200)
       val (runCode, runRes) = c.run(runPayload(data))
       runCode should be(200)
+    }
+  }
+
+  it should "support array result" in {
+    val helloArrayCode =
+      """|export default (args: any) => {
+         |   return ["a", "b"]
+         |}
+         |""".stripMargin
+    val (out, err) = withActionContainer() { c =>
+      val (initCode, _) = c.init(initPayload(helloArrayCode))
+      initCode should be(200)
+      val (runCode, runRes) = c.runForJsArray(JsObject())
+      runCode should be(200)
+      runRes shouldBe Some(JsArray(JsString("a"), JsString("b")))
     }
   }
 }

--- a/tests/src/test/scala/runtime/actionContainers/SingleTest.scala
+++ b/tests/src/test/scala/runtime/actionContainers/SingleTest.scala
@@ -52,7 +52,7 @@ class SingleTest extends ActionProxyContainerTestUtils with WskActorSystem {
     }
   }
 
-  it should "support array result" in {
+  it should "support return array result" in {
     val helloArrayCode =
       """|export default (args: any) => {
          |   return ["a", "b"]
@@ -61,7 +61,22 @@ class SingleTest extends ActionProxyContainerTestUtils with WskActorSystem {
     val (out, err) = withActionContainer() { c =>
       val (initCode, _) = c.init(initPayload(helloArrayCode))
       initCode should be(200)
-      val (runCode, runRes) = c.runForJsArray(JsObject())
+      val (runCode, runRes) = c.runForJsArray(runPayload(JsObject()))
+      runCode should be(200)
+      runRes shouldBe Some(JsArray(JsString("a"), JsString("b")))
+    }
+  }
+
+  it should "support array as input param" in {
+    val helloArrayCode =
+      """|export default (args: any) => {
+         |   return args
+         |}
+         |""".stripMargin
+    val (out, err) = withActionContainer() { c =>
+      val (initCode, _) = c.init(initPayload(helloArrayCode))
+      initCode should be(200)
+      val (runCode, runRes) = c.runForJsArray(runPayload(JsArray(JsString("a"), JsString("b"))))
       runCode should be(200)
       runRes shouldBe Some(JsArray(JsString("a"), JsString("b")))
     }


### PR DESCRIPTION
Depend on below prs: 
- https://github.com/apache/openwhisk/pull/5290
- https://github.com/apache/openwhisk-runtime-go/pull/170

- [x] Support array result
  - [x] make deno runtime to support array result for common action
  - [x] make deno runtime to support array result for sequence action (support array as input param)